### PR TITLE
Allow users to specify custom actions for all matching jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ QueueClassicAdmin.add_custom_action "Retry" do |job|
 end
 ```
 
+## Custom action on matching jobs
+
+```ruby
+QueueClassicAdmin.add_bulk_custom_action "Retry" do |jobs|
+  jobs.update_all(q_name: "low")
+end
+```
+
 # Development
 
 ```bash

--- a/app/controllers/queue_classic_admin/queue_classic_jobs_controller.rb
+++ b/app/controllers/queue_classic_admin/queue_classic_jobs_controller.rb
@@ -23,6 +23,15 @@ module QueueClassicAdmin
       redirect_to queue_classic_jobs_url
     end
 
+    def bulk_custom_action
+      jobs = filter_jobs(QueueClassicJob)
+
+      custom_action = QueueClassicAdmin.custom_bulk_actions[params[:custom_action]]
+      custom_action.action.call(jobs)
+
+      redirect_to queue_classic_jobs_url
+    end
+
     def unlock
       @queue_classic_job.locked_at = nil
       @queue_classic_job.save

--- a/app/views/queue_classic_admin/shared/_job_list.html.erb
+++ b/app/views/queue_classic_admin/shared/_job_list.html.erb
@@ -41,6 +41,9 @@
             link_to "Unlock Matching > 5 mins", url_for(params.merge(action: 'unlock_all')), class: 'btn btn-danger', data: {confirm: "Are you sure?", method: :put}
           %>
         <% end %>
+        <% QueueClassicAdmin.custom_bulk_actions.each do |slug, action| %>
+          <%= link_to action.name, bulk_custom_action_queue_classic_jobs_path(params.merge(custom_action: slug)), class: 'btn btn-danger', data: {confirm: "Are you sure?"} %>
+        <% end %>
       </th>
     </tr>
   </thead>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,13 +8,14 @@ QueueClassicAdmin::Engine.routes.draw do
   resources :queue_classic_jobs do
     collection do
       delete :destroy_all
-      put :unlock_all
+      put    :unlock_all
+      post   :bulk_custom_action
     end
 
     member do
       post :unlock
       post :custom
-      get :show
+      get  :show
     end
   end
 

--- a/lib/queue_classic_admin.rb
+++ b/lib/queue_classic_admin.rb
@@ -14,5 +14,14 @@ module QueueClassicAdmin
     action = CustomAction.new(name, &block)
     custom_actions[action.slug] = action
   end
+
+  def self.custom_bulk_actions
+    @@custom_actions ||= {}
+  end
+
+  def self.add_custom_bulk_action(name, &block)
+    action = CustomAction.new(name, &block)
+    custom_actions[action.slug] = action
+  end
 end
 

--- a/spec/controllers/queue_classic_admin/queue_classic_admin/queue_classic_jobs_controller_spec.rb
+++ b/spec/controllers/queue_classic_admin/queue_classic_admin/queue_classic_jobs_controller_spec.rb
@@ -71,6 +71,19 @@ module QueueClassicAdmin
       end
     end
 
+    context "#bulk_custom_action" do
+      it "runs the custom action on the jobs" do
+        custom_jobs = []
+        QueueClassicAdmin.add_custom_bulk_action("Test") { |jobs| custom_jobs = jobs }
+        job = queue_classic_job
+
+        post :bulk_custom_action, use_route: "queue_classic_admin", custom_action: "test"
+
+        expect(custom_jobs).to_not be_empty
+      end
+
+    end
+
     context "#unlock" do
       it "unlocks locked job" do
         locked_job = queue_classic_job


### PR DESCRIPTION
Works similarly to the custom action for a single job implementation.