### PR TITLE
Include the vendor dir in the gem files

### DIFF
--- a/queue_classic_admin.gemspec
+++ b/queue_classic_admin.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary     = "An admin interface for QueueClassic"
   s.description = "An admin interface for QueueClassic"
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", ">= 4.0.9"


### PR DESCRIPTION
For me, without this, an error is thrown because the engine cannot find the bootstrap css file which is nested in vendor (bc vendor is not pulled down to file system when installing gem)