### PR TITLE
Travis: Use stable releases of Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ before_script:
   - "bundle exec rake db:create"
   - "bundle exec rake db:schema:load RAILS_ENV=test"
 rvm:
-  - 2.1.2
-  - 2.0.0
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
 addons:
   postgresql: "9.3"


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.