### PR TITLE
Rails 5.1 deprecations

### DIFF
--- a/db/migrate/20130626182618_add_id_to_later.rb
+++ b/db/migrate/20130626182618_add_id_to_later.rb
@@ -1,7 +1,17 @@
-class AddIdToLater < ActiveRecord::Migration
+class AddIdToLater < ActiveRecord::Migration[4.2]
   def change
-    if ActiveRecord::Base.connection.table_exists?(:queue_classic_later_jobs)
+    if table_already_exists?(:queue_classic_later_jobs)
       add_column :queue_classic_later_jobs, :id, :primary_key
+    end
+  end
+
+  private
+
+  def table_already_exists?(table)
+    if ActiveRecord::Base.connection.respond_to?(:data_source_exists?)
+      ActiveRecord::Base.connection.data_source_exists?(table)
+    else
+      ActiveRecord::Base.connection.table_exists?(table)
     end
   end
 end

--- a/db/migrate/20130627175128_add_created_column.rb
+++ b/db/migrate/20130627175128_add_created_column.rb
@@ -1,10 +1,10 @@
-class AddCreatedColumn < ActiveRecord::Migration
+class AddCreatedColumn < ActiveRecord::Migration[4.2]
   def up
     %w(queue_classic_later_jobs).each do |table|
-      if ActiveRecord::Base.connection.table_exists?(table)
+      if table_already_exists?(table)
         execute "ALTER TABLE #{table} ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT now();"
       else
-        say "Skiping migration because table #{table} does not exist"
+        say "Skipping migration because table #{table} does not exist"
       end
     end
   end
@@ -12,6 +12,16 @@ class AddCreatedColumn < ActiveRecord::Migration
   def down
     %w(queue_classic_later_jobs).each do |table|
       remove_column table, :created_at
+    end
+  end
+
+  private
+
+  def table_already_exists?(table)
+    if ActiveRecord::Base.connection.respond_to?(:data_source_exists?)
+      ActiveRecord::Base.connection.data_source_exists?(table)
+    else
+      ActiveRecord::Base.connection.table_exists?(table)
     end
   end
 end

--- a/spec/dummy/db/migrate/20130626005404_setup_q_classic.rb
+++ b/spec/dummy/db/migrate/20130626005404_setup_q_classic.rb
@@ -1,4 +1,4 @@
-class SetupQClassic < ActiveRecord::Migration
+class SetupQClassic < ActiveRecord::Migration[4.2]
   def up
     QC::Setup.create
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,22 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130627175128) do
+ActiveRecord::Schema.define(version: 20130626005404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "queue_classic_jobs", id: :bigserial, force: :cascade do |t|
-    t.text     "q_name",                         null: false
-    t.text     "method",                         null: false
-    t.json     "args",                           null: false
+  create_table "queue_classic_jobs", force: :cascade do |t|
+    t.text "q_name", null: false
+    t.text "method", null: false
+    t.json "args", null: false
     t.datetime "locked_at"
-    t.integer  "locked_by"
-    t.datetime "created_at",   default: "now()"
-    t.datetime "scheduled_at", default: "now()"
+    t.integer "locked_by"
+    t.datetime "created_at", default: -> { "now()" }
+    t.datetime "scheduled_at", default: -> { "now()" }
+    t.index ["q_name", "id"], name: "idx_qc_on_name_only_unlocked", where: "(locked_at IS NULL)"
+    t.index ["scheduled_at", "id"], name: "idx_qc_on_scheduled_at_only_unlocked", where: "(locked_at IS NULL)"
   end
-
-  add_index "queue_classic_jobs", ["q_name", "id"], name: "idx_qc_on_name_only_unlocked", where: "(locked_at IS NULL)", using: :btree
-  add_index "queue_classic_jobs", ["scheduled_at", "id"], name: "idx_qc_on_scheduled_at_only_unlocked", where: "(locked_at IS NULL)", using: :btree
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
This PR is a **work in progress** to try to get this administration view to work on a current Rails.

- RSpec deprecated autorun
- Migrations ought to derive from a version, so I used `[4.2]` from the error message output by 5.1.1