### PR TITLE
CI: Use latest patch releases of Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ before_script:
   - "bundle exec rake db:create"
   - "bundle exec rake db:schema:load RAILS_ENV=test"
 rvm:
-  - 2.4.6
-  - 2.3.8
-  - 2.2.10
+  - 2.6.4
+  - 2.5.6
+  - 2.4.7
 addons:
   postgresql: "9.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
   - 2.3.8
   - 2.2.10
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script:
   - "bundle exec rake db:create"
   - "bundle exec rake db:schema:load RAILS_ENV=test"
 rvm:
+  - 2.7.0-preview1
   - 2.6.4
   - 2.5.6
   - 2.4.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ before_script:
   - "bundle exec rake db:create"
   - "bundle exec rake db:schema:load RAILS_ENV=test"
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
+  - 2.4.6
+  - 2.3.8
+  - 2.2.10
 addons:
   postgresql: "9.3"


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known