### PR TITLE
Use #column_for_attribute rather than #column_types

### DIFF
--- a/app/models/queue_classic_admin/job_common.rb
+++ b/app/models/queue_classic_admin/job_common.rb
@@ -30,7 +30,7 @@ module QueueClassicAdmin
       end
 
       def args_is_json?
-        self.column_types["args"].type == :json
+        self.column_for_attribute["args"].type == :json
       end
     end
 


### PR DESCRIPTION
The former is documented in both Rails 4 and Rails 5. The latter was a :no-doc: in Rails 4 and removed in Rails 5.

https://stackoverflow.com/a/38785590/1612744